### PR TITLE
CDC #212 - Index user-defined fields

### DIFF
--- a/app/services/user_defined_fields/converter.rb
+++ b/app/services/user_defined_fields/converter.rb
@@ -1,0 +1,41 @@
+module UserDefinedFields
+  module Converter
+    extend ActiveSupport::Concern
+
+    included do
+      def convert_value(user_defined_field, value)
+        return nil unless value.present?
+
+        if user_defined_field.data_type == UserDefinedField::DATA_TYPES[:boolean]
+          value.to_bool
+        elsif user_defined_field.data_type == UserDefinedField::DATA_TYPES[:date]
+          convert_date(value)
+        elsif user_defined_field.data_type == UserDefinedField::DATA_TYPES[:number]
+          value.to_i
+        elsif user_defined_field.data_type == UserDefinedField::DATA_TYPES[:select] && user_defined_field.allow_multiple
+          convert_array(value)
+        else
+          value
+        end
+      end
+
+      private
+
+      def convert_array(value)
+        begin
+          JSON.parse(value)
+        rescue StandardError
+          nil
+        end
+      end
+
+      def convert_date(value)
+        begin
+          DateTime.parse(value)&.to_time&.to_i
+        rescue Date::Error
+          nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the `converter` class to help with converting user-defined string values on the `data_type` attribute. This is in support of [#212](https://github.com/performant-software/core-data-cloud/issues/212) for Core Data.