### PR TITLE
Coerce string OR boolean value in boolean-type UDF to boolean (CDC #378)

### DIFF
--- a/app/services/user_defined_fields/converter.rb
+++ b/app/services/user_defined_fields/converter.rb
@@ -4,10 +4,10 @@ module UserDefinedFields
 
     included do
       def convert_value(user_defined_field, value)
-        return nil unless value.present?
+        return nil unless value.present? or value == false
 
         if user_defined_field.data_type == UserDefinedField::DATA_TYPES[:boolean]
-          conert_bool(value)
+          convert_bool(value)
         elsif user_defined_field.data_type == UserDefinedField::DATA_TYPES[:date]
           convert_date(value)
         elsif user_defined_field.data_type == UserDefinedField::DATA_TYPES[:number]
@@ -35,7 +35,7 @@ module UserDefinedFields
         elsif value.in? [true, false]
           value
         else
-          nil
+          false
         end
       end
 

--- a/app/services/user_defined_fields/converter.rb
+++ b/app/services/user_defined_fields/converter.rb
@@ -7,7 +7,7 @@ module UserDefinedFields
         return nil unless value.present?
 
         if user_defined_field.data_type == UserDefinedField::DATA_TYPES[:boolean]
-          value.to_bool
+          conert_bool(value)
         elsif user_defined_field.data_type == UserDefinedField::DATA_TYPES[:date]
           convert_date(value)
         elsif user_defined_field.data_type == UserDefinedField::DATA_TYPES[:number]
@@ -25,6 +25,16 @@ module UserDefinedFields
         begin
           JSON.parse(value)
         rescue StandardError
+          nil
+        end
+      end
+
+      def convert_bool(value)
+        if value.is_a? String
+          value.to_bool
+        elsif value.in? [true, false]
+          value
+        else
           nil
         end
       end


### PR DESCRIPTION
## In this PR

Per performant-software/core-data-cloud#378:
- Since Core Data Cloud actually passes a boolean `true` or `false` to user-defined-fields convert method, handle that in addition to strings for a boolean-type UDF

## Questions

- Is it ok that this will still return `nil` when the value is `false` since `value.present?` will return `false` for boolean `false`?
- Do we actually still need to handle strings here given that CDC passes a boolean? (or should we modify CDC to always pass a string instead?)